### PR TITLE
Fix decimal.Decimal serialization in process_record

### DIFF
--- a/target_gcs/sinks.py
+++ b/target_gcs/sinks.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from io import FileIO
 from typing import Optional
 
+import decimal
+
 import orjson
 import smart_open
 from google.cloud.storage import Client
@@ -82,5 +84,16 @@ class GCSSink(RecordSink):
         passed `context` dict from the current batch.
         """
         self.gcs_write_handle.write(
-            orjson.dumps(record, option=orjson.OPT_APPEND_NEWLINE)
+            orjson.dumps(
+                record,
+                option=orjson.OPT_APPEND_NEWLINE,
+                default=_default_serializer,
+            )
         )
+
+
+def _default_serializer(obj):
+    """Handle types that orjson cannot serialize natively."""
+    if isinstance(obj, decimal.Decimal):
+        return float(obj)
+    raise TypeError(f"Type is not JSON serializable: {type(obj)}")


### PR DESCRIPTION
## Summary
- Add a `default` serializer to `orjson.dumps()` in `GCSSink.process_record` to handle `decimal.Decimal` values by converting them to `float`
- `singer-sdk` 0.40+ passes `Decimal` for numeric fields (for precision), but `orjson` cannot serialize them natively

Fixes #72

## Test plan
- [ ] Run target-gcs with a tap that produces `decimal.Decimal` values (e.g. account balances)
- [ ] Verify records are written to GCS without `TypeError`
- [ ] Verify numeric precision is preserved (float conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)